### PR TITLE
Filtering by request parameters concept

### DIFF
--- a/persistence/src/main/java/edu/softserve/zoo/persistence/specification/impl/HouseFilterSpecification.java
+++ b/persistence/src/main/java/edu/softserve/zoo/persistence/specification/impl/HouseFilterSpecification.java
@@ -1,8 +1,6 @@
 package edu.softserve.zoo.persistence.specification.impl;
 
 import edu.softserve.zoo.model.House;
-import edu.softserve.zoo.model.ZooZone;
-import edu.softserve.zoo.persistence.specification.Specification;
 import edu.softserve.zoo.persistence.specification.hibernate.DetachedCriteriaSpecification;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Restrictions;
@@ -10,22 +8,23 @@ import org.hibernate.criterion.Restrictions;
 /**
  * @author Ilya Doroshenko
  */
-public class HouseSpecification implements DetachedCriteriaSpecification<House> {
-    private static final String ZONE_ID = "zone.id";
-    private static final String MAX_CAPACITY = "maxCapacity";
+public class HouseFilterSpecification implements DetachedCriteriaSpecification<House> {
+    private static final String ZONE_ID_FIELD = "zone.id";
+    private static final String MAX_CAPACITY_FIELD = "maxCapacity";
 
+    /* Filtering parameters. Ignored if null */
     private Long zoneId;
     private Integer maxCapacity;
 
-    public HouseSpecification() {
+    public HouseFilterSpecification() {
     }
 
     @Override
     public DetachedCriteria query() {
         DetachedCriteria criteria = DetachedCriteria.forClass(House.class);
 
-        addRestrictionIfNotNull(criteria, MAX_CAPACITY, maxCapacity);
-        addRestrictionIfNotNull(criteria, ZONE_ID, zoneId);
+        addRestrictionIfNotNull(criteria, MAX_CAPACITY_FIELD, maxCapacity);
+        addRestrictionIfNotNull(criteria, ZONE_ID_FIELD, zoneId);
 
         return criteria;
     }

--- a/persistence/src/main/java/edu/softserve/zoo/persistence/specification/impl/HouseSpecification.java
+++ b/persistence/src/main/java/edu/softserve/zoo/persistence/specification/impl/HouseSpecification.java
@@ -1,0 +1,54 @@
+package edu.softserve.zoo.persistence.specification.impl;
+
+import edu.softserve.zoo.model.House;
+import edu.softserve.zoo.model.ZooZone;
+import edu.softserve.zoo.persistence.specification.Specification;
+import edu.softserve.zoo.persistence.specification.hibernate.DetachedCriteriaSpecification;
+import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.Restrictions;
+
+/**
+ * @author Ilya Doroshenko
+ */
+public class HouseSpecification implements DetachedCriteriaSpecification<House> {
+    private static final String ZONE_ID = "zone.id";
+    private static final String MAX_CAPACITY = "maxCapacity";
+
+    private Long zoneId;
+    private Integer maxCapacity;
+
+    public HouseSpecification() {
+    }
+
+    @Override
+    public DetachedCriteria query() {
+        DetachedCriteria criteria = DetachedCriteria.forClass(House.class);
+
+        addRestrictionIfNotNull(criteria, MAX_CAPACITY, maxCapacity);
+        addRestrictionIfNotNull(criteria, ZONE_ID, zoneId);
+
+        return criteria;
+    }
+
+    private void addRestrictionIfNotNull(DetachedCriteria criteria, String propertyName, Object value) {
+        if (value != null) {
+            criteria.add(Restrictions.eq(propertyName, value));
+        }
+    }
+
+    public Long getZoneId() {
+        return zoneId;
+    }
+
+    public void setZoneId(Long zoneId) {
+        this.zoneId = zoneId;
+    }
+
+    public Integer getMaxCapacity() {
+        return maxCapacity;
+    }
+
+    public void setMaxCapacity(Integer maxCapacity) {
+        this.maxCapacity = maxCapacity;
+    }
+}

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     compile project(':persistence')
     testCompile spring_test
+    compile jackson
 }

--- a/service/src/main/java/edu/softserve/zoo/service/HouseService.java
+++ b/service/src/main/java/edu/softserve/zoo/service/HouseService.java
@@ -1,6 +1,11 @@
 package edu.softserve.zoo.service;
 
 import edu.softserve.zoo.model.House;
+import edu.softserve.zoo.persistence.specification.Specification;
+import edu.softserve.zoo.persistence.specification.impl.HouseSpecification;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * House specific methods and business logic for service layer
@@ -8,4 +13,5 @@ import edu.softserve.zoo.model.House;
  * @author Serhii Alekseichenko
  */
 public interface HouseService extends Service<House> {
+    List<House> find(Map<String,String> filter);
 }

--- a/service/src/main/java/edu/softserve/zoo/service/HouseService.java
+++ b/service/src/main/java/edu/softserve/zoo/service/HouseService.java
@@ -1,8 +1,6 @@
 package edu.softserve.zoo.service;
 
 import edu.softserve.zoo.model.House;
-import edu.softserve.zoo.persistence.specification.Specification;
-import edu.softserve.zoo.persistence.specification.impl.HouseSpecification;
 
 import java.util.List;
 import java.util.Map;
@@ -13,5 +11,5 @@ import java.util.Map;
  * @author Serhii Alekseichenko
  */
 public interface HouseService extends Service<House> {
-    List<House> find(Map<String,String> filter);
+    List<House> find(Map<String, String> filter);
 }

--- a/service/src/main/java/edu/softserve/zoo/service/impl/HouseServiceImpl.java
+++ b/service/src/main/java/edu/softserve/zoo/service/impl/HouseServiceImpl.java
@@ -4,8 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.softserve.zoo.model.House;
 import edu.softserve.zoo.persistence.repository.HouseRepository;
 import edu.softserve.zoo.persistence.repository.Repository;
-import edu.softserve.zoo.persistence.specification.Specification;
-import edu.softserve.zoo.persistence.specification.impl.HouseSpecification;
+import edu.softserve.zoo.persistence.specification.impl.HouseFilterSpecification;
 import edu.softserve.zoo.service.HouseService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -35,8 +34,8 @@ public class HouseServiceImpl extends AbstractService<House> implements HouseSer
 
     @Override
     @Transactional
-    public List<House> find(Map<String,String> filter) {
-        HouseSpecification specification = objectMapper.convertValue(filter, HouseSpecification.class);
+    public List<House> find(Map<String, String> filter) {
+        HouseFilterSpecification specification = objectMapper.convertValue(filter, HouseFilterSpecification.class);
         return repository.find(specification);
     }
 }

--- a/service/src/main/java/edu/softserve/zoo/service/impl/HouseServiceImpl.java
+++ b/service/src/main/java/edu/softserve/zoo/service/impl/HouseServiceImpl.java
@@ -1,11 +1,18 @@
 package edu.softserve.zoo.service.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.softserve.zoo.model.House;
 import edu.softserve.zoo.persistence.repository.HouseRepository;
 import edu.softserve.zoo.persistence.repository.Repository;
+import edu.softserve.zoo.persistence.specification.Specification;
+import edu.softserve.zoo.persistence.specification.impl.HouseSpecification;
 import edu.softserve.zoo.service.HouseService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of {@link HouseService} logic for {@link House} entity
@@ -18,9 +25,18 @@ public class HouseServiceImpl extends AbstractService<House> implements HouseSer
     @Autowired
     private HouseRepository repository;
 
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Override
     Repository<House> getRepository() {
         return repository;
+    }
+
+    @Override
+    @Transactional
+    public List<House> find(Map<String,String> filter) {
+        HouseSpecification specification = objectMapper.convertValue(filter, HouseSpecification.class);
+        return repository.find(specification);
     }
 }

--- a/service/src/main/resources/spring/service-ctx.xml
+++ b/service/src/main/resources/spring/service-ctx.xml
@@ -5,4 +5,6 @@
 
     <import resource="classpath:spring/service-common-ctx.xml"/>
     <import resource="classpath:spring/persistence-ctx.xml"/>
+
+    <bean name="objectMapper" class="com.fasterxml.jackson.databind.ObjectMapper"/>
 </beans>

--- a/web/src/main/java/edu/softserve/zoo/controller/rest/HouseRestController.java
+++ b/web/src/main/java/edu/softserve/zoo/controller/rest/HouseRestController.java
@@ -2,14 +2,18 @@ package edu.softserve.zoo.controller.rest;
 
 import edu.softserve.zoo.dto.HouseDto;
 import edu.softserve.zoo.model.House;
+import edu.softserve.zoo.persistence.specification.impl.HouseSpecification;
 import edu.softserve.zoo.service.HouseService;
 import edu.softserve.zoo.service.Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static edu.softserve.zoo.controller.rest.Routes.HOUSES;
 
@@ -34,9 +38,9 @@ public class HouseRestController extends AbstractRestController<HouseDto, House>
         return houseService;
     }
 
-    @Override
     @RequestMapping(method = RequestMethod.GET)
-    public List<HouseDto> getAll() {
-        return super.getAll();
+    public List<HouseDto> getHousesFiltered(@RequestParam Map<String,String> allRequestParams) {
+        List<House> result = houseService.find(allRequestParams);
+        return converter.convertToDto(result);
     }
 }

--- a/web/src/main/java/edu/softserve/zoo/controller/rest/HouseRestController.java
+++ b/web/src/main/java/edu/softserve/zoo/controller/rest/HouseRestController.java
@@ -2,7 +2,6 @@ package edu.softserve.zoo.controller.rest;
 
 import edu.softserve.zoo.dto.HouseDto;
 import edu.softserve.zoo.model.House;
-import edu.softserve.zoo.persistence.specification.impl.HouseSpecification;
 import edu.softserve.zoo.service.HouseService;
 import edu.softserve.zoo.service.Service;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 


### PR DESCRIPTION
We've avoided bulky DAO classes but ended up with big service classes. For each filtering request(with its own combination of filters) we should make a corresponding method in controller, service and specification class.

example: /houses?zoneId=1&maxCapacity=20
leads to following infrastructure:
HouseController.getHousesByZoneIdAndMaxCapacity
HouseService.getHousesByZoneIdAndMaxCapacity
GetHousesByZoneIdAndMaxCapacity.class

But what about different combinations of multiple filters? Our controller and service classes will become a mess.

So what about approach like this? It's not perfect, but just for the proof of concept
